### PR TITLE
Some necessary changes in structure

### DIFF
--- a/src/Api/Emails.php
+++ b/src/Api/Emails.php
@@ -258,7 +258,8 @@ class Emails extends AbstractApi
                 $elements = array_map([$subResolver, 'resolve'], $elements);
 
                 return true;
-            });
+            })
+          ->setDefined('attachments');
 
         $optionsResolver->resolve($data);
 

--- a/src/Api/Emails.php
+++ b/src/Api/Emails.php
@@ -249,7 +249,6 @@ class Emails extends AbstractApi
                     ->setRequired('email')
                     ->setDefined('name')
                     ->setAllowedTypes('name', 'string')
-                    ->setRequired('name')
                     ->setDefined('messageId')
                     ->setAllowedTypes('messageId', 'string')
                     ->setRequired('messageId')

--- a/src/Plugin/Authentication.php
+++ b/src/Plugin/Authentication.php
@@ -72,7 +72,7 @@ final class Authentication implements Plugin
         $request = $request->withHeader('Authorization', $this->apikey);
 
         if (null != $this->appkey) {
-            if (ctype_space($this->appkey)) {
+            if (!ctype_space($this->appkey)) {
                 $request = $request->withHeader('Application-Key', $this->appkey);
             }
         }


### PR DESCRIPTION
I'm working with emaillabs API

# Description

Fixes # (Problem with required name)

## API allow empty name field, with only email field to whom we wan't to send email, so it should not be required

Fixes # (Attachments array)

## Ther was not defined in field list, returning validation error

Fiexes # (Wrong ctype_space condition)

ctype_space($this->appkey) condition incompatible with condition `plotkabytes/redlink-api-php-client/src/Plugin/Authentication.php:57`

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)